### PR TITLE
update AMM links

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@
 
 **Please** use **AMM** now. It is really great!
 
-- [Nexus Mods](https://www.nexusmods.com/anno1800/mods/35)
-- GitHub: [Download](https://github.com/LemonDrop1228/anno1800-mod-manager) / [Open Source](https://github.com/LemonDrop1228/AMM-Source-Code) :hammer:
+- [Download latest release from GitHub](https://github.com/RebuiltStatue21/AMM-Source-Code/releases)
+- Alternative download: [Nexus Mods](https://www.nexusmods.com/anno1800/mods/35)
 - [Anno 1800 Mod Manager Wiki](https://www.notion.so/Anno-1800-Mod-Manager-Wiki-60bbcd8ad9634c2faa225be3f1bd46d6)
 
 <br />


### PR DESCRIPTION
The links to repository and downloads are outdated.

Also, Nexus just points to GitHub releases again, but I left it there as an alternative (albeit not useful right now).